### PR TITLE
Issue in displaying of social media buttons list

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
             position: fixed;
             top: 50%;
             transform: translateY(-50%);
+            z-index: 1;
         }
 
         .stickyicon-list a {


### PR DESCRIPTION
Solves #70 | An issue related to the mobile view of the site. The social media icons used to get sliced and go behind the images.

**_Before_**

![image](https://user-images.githubusercontent.com/85112134/197389354-5b22f17c-9700-459c-9cd6-80cb7c72a413.png)

**_After_**

![image](https://user-images.githubusercontent.com/85112134/197389367-26893ecc-00e0-4f7b-a113-3d0a75c9a844.png)
